### PR TITLE
Captain's beret added to cap garment bag.

### DIFF
--- a/code/game/objects/items/storage/garment.dm
+++ b/code/game/objects/items/storage/garment.dm
@@ -62,6 +62,7 @@
 	new /obj/item/clothing/head/hats/caphat/parade(src)
 	new /obj/item/clothing/neck/cloak/cap(src)
 	new /obj/item/clothing/shoes/laceup(src)
+	new /obj/item/clothing/head/caphat/beret(src)
 
 /obj/item/storage/bag/garment/hop/PopulateContents()
 	new /obj/item/clothing/under/rank/civilian/head_of_personnel(src)


### PR DESCRIPTION
## About The Pull Request

This PR adds the unused captain's beret to the captain's garment bag.

## Why It's Good For The Game

It looks nice and is perfectly functional. The only concern would be another hat with the captain's helmet stats on station every round, but I reckon its likely negligible.

![image](https://github.com/user-attachments/assets/c127acee-d0f1-4382-b1b6-04557e145990)
Doesn't that look snazzy? (maybe the blue it uses is a bit too bright, but eh)

## Changelog

:cl:
add: The unused captain's beret is now in the captain's garment bag.
/:cl:
