### PR TITLE
Combat knives are purchasable from cargo again.

### DIFF
--- a/code/modules/cargo/goodies.dm
+++ b/code/modules/cargo/goodies.dm
@@ -337,5 +337,5 @@
 /datum/supply_pack/goody/combatknives_single
 	name = "Combat Knife Single-Pack"
 	desc = "Contains one sharpened combat knive. Guaranteed to fit snugly inside any Nanotrasen-standard boot."
-	cost = PAYCHECK_COMMAND * 2.5
+	cost = PAYCHECK_COMMAND * 3.5
 	contains = list(/obj/item/knife/combat)

--- a/code/modules/cargo/goodies.dm
+++ b/code/modules/cargo/goodies.dm
@@ -333,3 +333,9 @@
 	desc = "A single bottle of Interdyne brand experimental medication, used for treating people suffering from hereditary manifold disease."
 	cost = PAYCHECK_CREW * 6.5
 	contains = list(/obj/item/storage/pill_bottle/sansufentanyl)
+
+/datum/supply_pack/goody/combatknives_single
+	name = "Combat Knife Single-Pack"
+	desc = "Contains one sharpened combat knive. Guaranteed to fit snugly inside any Nanotrasen-standard boot."
+	cost = PAYCHECK_COMMAND * 2.5
+	contains = list(/obj/item/knife/combat)

--- a/code/modules/cargo/packs/security.dm
+++ b/code/modules/cargo/packs/security.dm
@@ -347,3 +347,12 @@
 	access_view = ACCESS_SECURITY
 	contains = list(/obj/item/clothing/glasses/sunglasses = 1)
 	crate_name = "sunglasses crate"
+
+/datum/supply_pack/security/armory/combatknives
+	name = "Combat Knives Crate"
+	desc = "Contains three sharpened combat knives. Each knife guaranteed to fit snugly inside any Nanotrasen-standard boot. Requires Armory access to open."
+	cost = CARGO_CRATE_VALUE * 4.5
+	contains = list(/obj/item/knife/combat,
+					/obj/item/knife/combat,
+					/obj/item/knife/combat)
+	crate_name = "combat knife crate"


### PR DESCRIPTION
## About The Pull Request

This PR re-adds combat knives to cargo orders. A 3-three is specifically available to security, while a single combat knife is purchasable as a good by anyone. Survival knives have been kept in there as well, with the combat knives being more expensive because they're simply better.

## Why It's Good For The Game

If security needs combat knives for something, they can get them now. If an individual would like to purchase a combat knife, they're also free to do so, assuming they can pay the fee.

## Changelog

:cl:
add: The combat knife 3-pack has been re-added to security's cargo orders.
add: The single combat knife goody order has been re-added to personal cargo orders, but is far more expensive than purchasing a survival knife.
/:cl: