### PR TITLE
Re-Adds Tactical Resting

### DIFF
--- a/code/modules/projectiles/ammunition/_firing.dm
+++ b/code/modules/projectiles/ammunition/_firing.dm
@@ -44,7 +44,6 @@
 	loaded_projectile.original = target
 	loaded_projectile.firer = user
 	loaded_projectile.fired_from = fired_from
-	loaded_projectile.hit_prone_targets = user.combat_mode
 	if (zone_override)
 		loaded_projectile.def_zone = zone_override
 	else

--- a/code/modules/vehicles/mecha/equipment/weapons/weapons.dm
+++ b/code/modules/vehicles/mecha/equipment/weapons/weapons.dm
@@ -69,9 +69,6 @@
 		projectile_obj.log_override = TRUE //we log being fired ourselves a little further down.
 		projectile_obj.firer = chassis
 		projectile_obj.aim_projectile(target, source, modifiers, spread)
-		if(isliving(source) && source.client) //dont want it to happen from syndie mecha npc mobs, they do direct fire anyways
-			var/mob/living/shooter = source
-			projectile_obj.hit_prone_targets = shooter.combat_mode
 		projectile_obj.fire()
 		if(!projectile_obj.suppressed && firing_effect_type)
 			new firing_effect_type(chassis || get_turf(src), chassis.dir)


### PR DESCRIPTION
## About The Pull Request

This PR re-adds tactical rests to the game. What that means is, if you're lying prone on the ground, in order to be hit by projectiles they need to be directly aimed at you for them to hit.

## Why It's Good For The Game

Adds some more counterplay and skill-based gameplay when it comes to dealing with projectiles. There's some concerns I have with how this may impact some interactions (conveyor belts mostly) but I'm willing to see this feature play out first before making additional adjustments.

## Changelog
:cl:
add: Tactical resting is back.
/:cl: