### PR TITLE
Re-add water potassium chem purge

### DIFF
--- a/code/modules/reagents/chemistry/recipes.dm
+++ b/code/modules/reagents/chemistry/recipes.dm
@@ -281,7 +281,7 @@
  * * modifier - a flat additive numeric to the size of the explosion - set this if you want a minimum range
  * * strengthdiv - the divisional factor of the explosion, a larger number means a smaller range - This is the part that modifies an explosion's range with volume (i.e. it divides it by this number)
  */
-/datum/chemical_reaction/proc/default_explode(datum/reagents/holder, created_volume, modifier = 0, strengthdiv = 10, clear_mob_reagents)
+/datum/chemical_reaction/proc/default_explode(datum/reagents/holder, created_volume, modifier = 0, strengthdiv = 10)
 	var/power = modifier + round(created_volume/strengthdiv, 1)
 	if(power > 0)
 		var/turf/T = get_turf(holder.my_atom)
@@ -300,29 +300,7 @@
 		var/datum/effect_system/reagents_explosion/e = new()
 		e.set_up(power , T, 0, 0)
 		e.start(holder.my_atom)
-	if (ismob(holder.my_atom))
-		if(!clear_mob_reagents)
-			return
-		// Only clear reagents if they use a special explosive reaction to do it; it shouldn't apply
-		// to any explosion inside a person
-		holder.clear_reagents()
-		if(iscarbon(holder.my_atom))
-			var/mob/living/carbon/victim = holder.my_atom
-			var/vomit_flags = MOB_VOMIT_MESSAGE | MOB_VOMIT_FORCE
-			// The vomiting here is for effect, not meant to help with purging
-			victim.vomit(vomit_flags, distance = 5)
-		// Not quite the same if the reaction is in their stomach; they'll throw up
-		// from any explosion, but it'll only make them puke up everything in their
-		// stomach
-	else if (istype(holder.my_atom, /obj/item/organ/stomach))
-		var/obj/item/organ/stomach/indigestion = holder.my_atom
-		if(power < 1)
-			return
-		indigestion.owner?.vomit(MOB_VOMIT_MESSAGE | MOB_VOMIT_FORCE, lost_nutrition = 150, distance = 5, purge_ratio = 1)
-		holder.clear_reagents()
-		return
-	else
-		holder.clear_reagents()
+	holder.clear_reagents()
 /*
  *Creates a flash effect only - less expensive than explode()
  *

--- a/code/modules/reagents/chemistry/recipes/pyrotechnics.dm
+++ b/code/modules/reagents/chemistry/recipes/pyrotechnics.dm
@@ -1,12 +1,3 @@
-#define PURGING_REAGENTS list( \
-	/datum/reagent/medicine/c2/multiver, \
-	/datum/reagent/medicine/pen_acid, \
-	/datum/reagent/medicine/calomel, \
-	/datum/reagent/medicine/ammoniated_mercury, \
-	/datum/reagent/medicine/c2/syriniver, \
-	/datum/reagent/medicine/c2/musiver \
-)
-
 /datum/chemical_reaction/reagent_explosion
 	var/strengthdiv = 10
 	var/modifier = 0
@@ -16,33 +7,10 @@
 	// Only clear mob reagents in special cases
 	var/clear_mob_reagents = FALSE
 
-/datum/chemical_reaction/reagent_explosion/on_reaction(datum/reagents/holder, datum/equilibrium/reaction, created_volume, clear_mob_reagents)
-	// If an explosive reaction clears mob reagents, it should always be a minimum power
-	if(ismob(holder.my_atom) && clear_mob_reagents)
-		if(round((created_volume / strengthdiv) + modifier, 1) < 1)
-			modifier += 1 - ((created_volume / strengthdiv) + modifier)
-	// If this particular explosion doesn't automatically clear mob reagents as an inherent quality,
-	// then we can still clear mob reagents with some mad science malpractice that shouldn't work but
-	// does because omnizine is magic and also it's the future or whatever
-	if(ismob(holder.my_atom) && !clear_mob_reagents)
-		// The explosion needs to be a minimum power to clear reagents: see above
-		var/purge_power = round((created_volume / strengthdiv) + modifier, 1)
-		if(purge_power >= 1)
-			var/has_purging_chemical = FALSE
-			// They need one of the purge reagents in them
-			for(var/purging_chem as anything in PURGING_REAGENTS)
-				if(holder.has_reagent(purging_chem))
-					// We have a purging chemical
-					has_purging_chemical = TRUE
-					break
-			// Then we need omnizine! MAGIC!
-			var/has_omnizine = holder.has_reagent(/datum/reagent/medicine/omnizine)
-			if(has_purging_chemical && has_omnizine)
-				// With all this medical "science" combined, we can clear mob reagents
-				clear_mob_reagents = TRUE
-	default_explode(holder, created_volume, modifier, strengthdiv, clear_mob_reagents)
 
-#undef PURGING_REAGENTS
+/datum/chemical_reaction/reagent_explosion/on_reaction(datum/reagents/holder, datum/equilibrium/reaction, created_volume)
+	default_explode(holder, created_volume, modifier, strengthdiv)
+
 /datum/chemical_reaction/reagent_explosion/nitroglycerin
 	results = list(/datum/reagent/nitroglycerin = 2)
 	required_reagents = list(/datum/reagent/glycerol = 1, /datum/reagent/toxin/acid/nitracid = 1, /datum/reagent/toxin/acid = 1)
@@ -139,18 +107,11 @@
 /datum/chemical_reaction/reagent_explosion/penthrite_explosion_epinephrine
 	required_reagents = list(/datum/reagent/medicine/c2/penthrite = 1, /datum/reagent/medicine/epinephrine = 1)
 	strengthdiv = 5
-	// Penthrite is rare as hell, so this clears your reagents
-	// Will most likely be from miners accidentally penstacking
-	clear_mob_reagents = TRUE
-
 
 /datum/chemical_reaction/reagent_explosion/penthrite_explosion_atropine
 	required_reagents = list(/datum/reagent/medicine/c2/penthrite = 1, /datum/reagent/medicine/atropine = 1)
 	strengthdiv = 5
 	modifier = 5
-	// Rare reagents clear your reagents
-	// Probably not good for you because you'll need healing chems to survive this most likely
-	clear_mob_reagents = TRUE
 
 /datum/chemical_reaction/reagent_explosion/potassium_explosion
 	required_reagents = list(/datum/reagent/water = 1, /datum/reagent/potassium = 1)


### PR DESCRIPTION
## About The Pull Request

Re-adds the water-potassium chem purge by making any internal explosion purge all chems again.

## Why It's Good For The Game

Chemists wanted it. Wasn't popular on /tg/ when it got removed.

## Changelog


:cl:
add: Any internal explosion will purge all chems again.
/:cl:
