### PR TITLE
Lethal Shotgun Material Rebalancing

### DIFF
--- a/code/modules/research/designs/autolathe/security_designs.dm
+++ b/code/modules/research/designs/autolathe/security_designs.dm
@@ -268,7 +268,7 @@
 	name = "Shotgun Slug"
 	id = "shotgun_slug"
 	build_type = AUTOLATHE
-	materials = list(/datum/material/iron = 4000)
+	materials = list(/datum/material/iron = SMALL_MATERIAL_AMOUNT * 10)
 	build_path = /obj/item/ammo_casing/shotgun
 	category = list(
 		RND_CATEGORY_HACKED,
@@ -280,8 +280,32 @@
 	name = "Buckshot Shell"
 	id = "buckshot_shell"
 	build_type = AUTOLATHE
-	materials = list(/datum/material/iron = 4000)
+	materials = list(/datum/material/iron = SMALL_MATERIAL_AMOUNT * 10)
 	build_path = /obj/item/ammo_casing/shotgun/buckshot
+	category = list(
+		RND_CATEGORY_HACKED,
+		RND_CATEGORY_WEAPONS + RND_SUBCATEGORY_WEAPONS_AMMO,
+	)
+	departmental_flags = DEPARTMENT_BITFLAG_SECURITY
+
+/datum/design/buckshot_box
+	name = "Buckshot Ammo Box (12g) (Lethal)"
+	id = "buckshot_box"
+	build_type = AUTOLATHE
+	materials = list(/datum/material/iron =SMALL_MATERIAL_AMOUNT * 300)
+	build_path = /obj/item/storage/box/lethalshot
+	category = list(
+		RND_CATEGORY_HACKED,
+		RND_CATEGORY_WEAPONS + RND_SUBCATEGORY_WEAPONS_AMMO,
+	)
+	departmental_flags = DEPARTMENT_BITFLAG_SECURITY
+
+/datum/design/slug_box
+	name = "Slug Ammo Box (12g) (Lethal)"
+	id = "slug_box"
+	build_type = AUTOLATHE
+	materials = list(/datum/material/iron =SMALL_MATERIAL_AMOUNT * 300)
+	build_path = /obj/item/storage/box/slugs
 	category = list(
 		RND_CATEGORY_HACKED,
 		RND_CATEGORY_WEAPONS + RND_SUBCATEGORY_WEAPONS_AMMO,

--- a/code/modules/research/designs/autolathe/security_designs.dm
+++ b/code/modules/research/designs/autolathe/security_designs.dm
@@ -268,7 +268,7 @@
 	name = "Shotgun Slug"
 	id = "shotgun_slug"
 	build_type = AUTOLATHE
-	materials = list(/datum/material/iron = SMALL_MATERIAL_AMOUNT * 10)
+	materials = list(/datum/material/iron = SMALL_MATERIAL_AMOUNT * 75)
 	build_path = /obj/item/ammo_casing/shotgun
 	category = list(
 		RND_CATEGORY_HACKED,
@@ -280,7 +280,7 @@
 	name = "Buckshot Shell"
 	id = "buckshot_shell"
 	build_type = AUTOLATHE
-	materials = list(/datum/material/iron = SMALL_MATERIAL_AMOUNT * 10)
+	materials = list(/datum/material/iron = SMALL_MATERIAL_AMOUNT * 75)
 	build_path = /obj/item/ammo_casing/shotgun/buckshot
 	category = list(
 		RND_CATEGORY_HACKED,
@@ -292,7 +292,7 @@
 	name = "Buckshot Ammo Box (12g) (Lethal)"
 	id = "buckshot_box"
 	build_type = AUTOLATHE
-	materials = list(/datum/material/iron =SMALL_MATERIAL_AMOUNT * 300)
+	materials = list(/datum/material/iron =SMALL_MATERIAL_AMOUNT * 350)
 	build_path = /obj/item/storage/box/lethalshot
 	category = list(
 		RND_CATEGORY_HACKED,
@@ -304,7 +304,7 @@
 	name = "Slug Ammo Box (12g) (Lethal)"
 	id = "slug_box"
 	build_type = AUTOLATHE
-	materials = list(/datum/material/iron =SMALL_MATERIAL_AMOUNT * 300)
+	materials = list(/datum/material/iron =SMALL_MATERIAL_AMOUNT * 350)
 	build_path = /obj/item/storage/box/slugs
 	category = list(
 		RND_CATEGORY_HACKED,


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adjusts the material values of 12g Buckshot and Slug Shells in the Autolath to be actually reasonable.

Additionally adds the option to print 12g Slug and Buckshot boxes

## Why It's Good For The Game
The material values for buckshot were probably passed over during a material rebalancing, making a SINGULAR shell cost over 50 sheets of iron, this fixes that oversight and adjusts them to a more normal value.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: SELFHELL
add: 12g Buckshot Boxes to Hacked Authlathes
add: 12g Slug Boxes to Hacked Autolathes
balance: Adjusted the costs of 12g Buckshot and Slugs in Hacked Autolathes
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
