### PR TITLE
Changeling Horror Form Fixes

### DIFF
--- a/code/modules/antagonists/changeling/changeling.dm
+++ b/code/modules/antagonists/changeling/changeling.dm
@@ -474,41 +474,39 @@
 /datum/antagonist/changeling/proc/can_absorb_dna(mob/living/carbon/human/target, verbose = TRUE)
 	if(!target)
 		return FALSE
-	if(!iscarbon(owner.current))
-		return FALSE
-	var/mob/living/carbon/user = owner.current
-
-	if(stored_profiles.len)
-		// If our current DNA is the stalest, we gotta ditch it before absorbing more.
-		var/datum/changeling_profile/top_profile = stored_profiles[1]
-		if(top_profile.dna.is_same_as(user.dna) && stored_profiles.len > dna_max)
-			if(verbose)
-				to_chat(user, span_warning("We have reached our capacity to store genetic information! We must transform before absorbing more."))
-			return FALSE
+	if(iscarbon(owner.current))
+		var/mob/living/carbon/user = owner.current
+		if(stored_profiles.len)
+			// If our current DNA is the stalest, we gotta ditch it before absorbing more.
+			var/datum/changeling_profile/top_profile = stored_profiles[1]
+			if(top_profile.dna.is_same_as(user.dna) && stored_profiles.len > dna_max)
+				if(verbose)
+					to_chat(user, span_warning("We have reached our capacity to store genetic information! We must transform before absorbing more."))
+				return FALSE
 
 	if(!target.has_dna())
 		if(verbose)
-			to_chat(user, span_warning("[target] is not compatible with our biology."))
+			to_chat(owner.current, span_warning("[target] is not compatible with our biology."))
 		return FALSE
 	if(has_profile_with_dna(target.dna))
 		if(verbose)
-			to_chat(user, span_warning("We already have this DNA in storage!"))
+			to_chat(owner.current, span_warning("We already have this DNA in storage!"))
 		return FALSE
 	if(HAS_TRAIT(target, TRAIT_NO_DNA_COPY))
 		if(verbose)
-			to_chat(user, span_warning("[target] is not compatible with our biology."))
+			to_chat(owner.current, span_warning("[target] is not compatible with our biology."))
 		return FALSE
 	if(HAS_TRAIT(target, TRAIT_BADDNA))
 		if(verbose)
-			to_chat(user, span_warning("[target]'s DNA is ruined beyond usability!"))
+			to_chat(owner.current, span_warning("[target]'s DNA is ruined beyond usability!"))
 		return FALSE
 	if(HAS_TRAIT(target, TRAIT_HUSK))
 		if(verbose)
-			to_chat(user, span_warning("[target]'s body is ruined beyond usability!"))
+			to_chat(owner.current, span_warning("[target]'s body is ruined beyond usability!"))
 		return FALSE
 	if(!ishuman(target) || ismonkey(target))//Absorbing monkeys is entirely possible, but it can cause issues with transforming. That's what lesser form is for anyway!
 		if(verbose)
-			to_chat(user, span_warning("We could gain no benefit from absorbing a lesser creature."))
+			to_chat(owner.current, span_warning("We could gain no benefit from absorbing a lesser creature."))
 		return FALSE
 
 	return TRUE

--- a/code/modules/antagonists/changeling/changeling_power.dm
+++ b/code/modules/antagonists/changeling/changeling_power.dm
@@ -22,6 +22,8 @@
 	var/req_dna = 0
 	/// If you need to be humanoid to use this ability (disincludes monkeys)
 	var/req_human = FALSE
+	/// If this ability is usable by the changeling if they are a basic mob (includes horror form)
+	var/usable_by_basicmobs = FALSE
 	/// Similar to req_dna, but only gained from absorbing, not DNA sting
 	var/req_absorbs = 0
 	/// Maximum stat before the ability is blocked.
@@ -107,6 +109,8 @@ the same goes for Remove(). if you override Remove(), call parent or else your p
 /datum/action/changeling/proc/can_be_used_by(mob/living/user)
 	if(QDELETED(user))
 		return FALSE
+	if(usable_by_basicmobs && isbasicmob(user) && !istype(user, /mob/living/basic/headslug))
+		return TRUE
 	if(!ishuman(user))
 		return FALSE
 	if(req_human && ismonkey(user))

--- a/code/modules/antagonists/changeling/powers/absorb.dm
+++ b/code/modules/antagonists/changeling/powers/absorb.dm
@@ -5,11 +5,12 @@
 	chemical_cost = 0
 	dna_cost = CHANGELING_POWER_INNATE
 	req_human = TRUE
+	usable_by_basicmobs = TRUE
 	///if we're currently absorbing, used for sanity
 	var/is_absorbing = FALSE
 	var/datum/looping_sound/changeling_absorb/absorbing_loop
 
-/datum/action/changeling/absorb_dna/can_sting(mob/living/carbon/owner)
+/datum/action/changeling/absorb_dna/can_sting(mob/living/owner)
 	if(!..())
 		return
 

--- a/code/modules/antagonists/changeling/powers/digitalcamo.dm
+++ b/code/modules/antagonists/changeling/powers/digitalcamo.dm
@@ -5,6 +5,7 @@
 	button_icon_state = "digital_camo"
 	dna_cost = 1
 	active = FALSE
+	usable_by_basicmobs = TRUE
 
 //Prevents AIs tracking you but makes you easily detectable to the human-eye.
 /datum/action/changeling/digitalcamo/sting_action(mob/user)

--- a/code/modules/antagonists/changeling/powers/fleshmend.dm
+++ b/code/modules/antagonists/changeling/powers/fleshmend.dm
@@ -6,11 +6,7 @@
 	chemical_cost = 20
 	dna_cost = 2
 	req_stat = HARD_CRIT
-
-/datum/action/changeling/fleshmend/can_be_used_by(mob/living/user)
-	if(QDELETED(user))
-		return FALSE
-	return TRUE
+	usable_by_basicmobs = TRUE
 
 //Starts healing you every second for 10 seconds.
 //Can be used whilst unconscious.

--- a/code/modules/antagonists/changeling/powers/horrorform.dm
+++ b/code/modules/antagonists/changeling/powers/horrorform.dm
@@ -8,15 +8,11 @@
 	button_icon_state = "horror_form"
 	chemical_cost = 45
 	dna_cost = 3
+	usable_by_basicmobs = TRUE
 
 /datum/action/changeling/horrorform/Remove(mob/remove_from)
 	unshift_owner()
 	return ..()
-
-/datum/action/changeling/horrorform/can_be_used_by(mob/living/user)
-	if(QDELETED(user))
-		return FALSE
-	return TRUE
 
 //Transform into horror form.
 /datum/action/changeling/horrorform/sting_action(mob/living/user)

--- a/code/modules/antagonists/changeling/powers/shriek.dm
+++ b/code/modules/antagonists/changeling/powers/shriek.dm
@@ -5,13 +5,8 @@
 	button_icon_state = "resonant_shriek"
 	chemical_cost = 20
 	dna_cost = 1
-	req_human = TRUE
+	usable_by_basicmobs = TRUE
 	disabled_by_fire = FALSE
-
-/datum/action/changeling/resonant_shriek/can_be_used_by(mob/living/user)
-	if(QDELETED(user))
-		return FALSE
-	return TRUE
 
 //A flashy ability, good for crowd control and sowing chaos.
 /datum/action/changeling/resonant_shriek/sting_action(mob/user)
@@ -53,11 +48,7 @@
 	chemical_cost = 20
 	dna_cost = 1
 	disabled_by_fire = FALSE
-
-/datum/action/changeling/dissonant_shriek/can_be_used_by(mob/living/user)
-	if(QDELETED(user))
-		return FALSE
-	return TRUE
+	usable_by_basicmobs = TRUE
 
 /datum/action/changeling/dissonant_shriek/sting_action(mob/user)
 	..()

--- a/code/modules/antagonists/changeling/powers/spiders.dm
+++ b/code/modules/antagonists/changeling/powers/spiders.dm
@@ -6,6 +6,7 @@
 	chemical_cost = 45
 	dna_cost = 1
 	req_absorbs = 3
+	usable_by_basicmobs = TRUE
 
 // Ensures that you cannot horrifically cheese the game by spawning spiders while in the vents
 /datum/action/changeling/spiders/can_be_used_by(mob/living/user)

--- a/code/modules/antagonists/changeling/powers/tiny_prick.dm
+++ b/code/modules/antagonists/changeling/powers/tiny_prick.dm
@@ -1,6 +1,7 @@
 /datum/action/changeling/sting//parent path, not meant for users afaik
 	name = "Tiny Prick"
 	desc = "Stabby stabby"
+	usable_by_basicmobs = TRUE
 
 /datum/action/changeling/sting/Trigger(trigger_flags)
 	var/mob/user = owner
@@ -31,7 +32,7 @@
 	changeling.lingstingdisplay.icon_state = null
 	changeling.lingstingdisplay.RemoveInvisibility(type)
 
-/mob/living/carbon/proc/unset_sting()
+/mob/living/proc/unset_sting()
 	if(mind)
 		var/datum/antagonist/changeling/changeling = mind.has_antag_datum(/datum/antagonist/changeling)
 		if(changeling?.chosen_sting)

--- a/code/modules/mob/living/basic/basic.dm
+++ b/code/modules/mob/living/basic/basic.dm
@@ -88,6 +88,8 @@
 	var/list/habitable_atmos = list("min_oxy" = 5, "max_oxy" = 0, "min_plas" = 0, "max_plas" = 1, "min_co2" = 0, "max_co2" = 5, "min_n2" = 0, "max_n2" = 0)
 	///This damage is taken when atmos doesn't fit all the requirements above. Set to 0 to avoid adding the atmos_requirements element.
 	var/unsuitable_atmos_damage = 1
+	///How quickly this mob heals oxygen damage when in an environment it deems habitable.
+	var/oxyloss_damage_healing = 1
 
 	///Minimal body temperature without receiving damage
 	var/minimum_survivable_temperature = NPC_DEFAULT_MIN_TEMP
@@ -135,7 +137,7 @@
 		return
 	//String assoc list returns a cached list, so this is like a static list to pass into the element below.
 	habitable_atmos = string_assoc_list(habitable_atmos)
-	AddElement(/datum/element/atmos_requirements, habitable_atmos, unsuitable_atmos_damage, mapload)
+	AddElement(/datum/element/atmos_requirements, habitable_atmos, unsuitable_atmos_damage, oxyloss_damage_healing, mapload)
 
 /// Ensures this mob can take temperature damage if it's supposed to
 /mob/living/basic/proc/apply_temperature_requirements(mapload)

--- a/code/modules/mob/living/basic/health_adjustment.dm
+++ b/code/modules/mob/living/basic/health_adjustment.dm
@@ -40,12 +40,9 @@
 		. = adjust_health(amount * damage_coeff[BURN] * CONFIG_GET(number/damage_multiplier), updating_health, forced)
 
 /mob/living/basic/adjustOxyLoss(amount, updating_health = TRUE, forced = FALSE, required_biotype, required_respiration_type)
-	if(!can_adjust_oxy_loss(amount, forced, required_biotype, required_respiration_type))
-		return 0
-	if(forced)
-		. = adjust_health(amount * CONFIG_GET(number/damage_multiplier), updating_health, forced)
-	else if(damage_coeff[OXY])
-		. = adjust_health(amount * damage_coeff[OXY] * CONFIG_GET(number/damage_multiplier), updating_health, forced)
+	if(!forced && HAS_TRAIT(src, TRAIT_NOBREATH))
+		amount = min(amount, 0) //Prevents oxy damage but not healing
+	. = ..()
 
 /mob/living/basic/adjustToxLoss(amount, updating_health = TRUE, forced = FALSE, required_biotype)
 	if(!can_adjust_tox_loss(amount, forced, required_biotype))


### PR DESCRIPTION
## About The Pull Request

This PR fixes some things about about Changeling Horror Form, namely:

- Instead of overriding the check whether the ability can be used, a new var has been added to changeling abilities to let them be used by basic mobs (which includes changeling horror form).
- Several more abilities have been made compatible with changeling horror form, including most stings, digital camo, and absorb.
- Basic mobs who are sensitive to atmos now properly take oxygen damage like carbons do, and heal oxygen damage when in proper conditions. Affects changeling horror form but also stuff like spiders will be greatly impacted by this.

## Why It's Good For The Game

Cleans up some of the shitcode I PR'd to have the horror form available during the last playtest, and makes using horror form more intuitive. Also makes taking oxygen damage as a basic mob not suck as much.

The basic mob compatibility stuff could be used for a changeling animal transformation in the future as well.

## Changelog

:cl:
add: Changeling horror form can use more abilities, namely most of the stings, digital camo and absorb.
qol: Basic mobs heal oxygen damage when in environments where they are able to breathe, like carbons do.
refactor: Added new variable to changeling abilities which allows them to be used by basic mobs.
/:cl:
