### PR TITLE
Fixes Reviving Basic Mobs

### DIFF
--- a/code/modules/mob/living/basic/basic.dm
+++ b/code/modules/mob/living/basic/basic.dm
@@ -192,6 +192,12 @@
 		ADD_TRAIT(src, TRAIT_UNDENSE, BASIC_MOB_DEATH_TRAIT)
 	SEND_SIGNAL(src, COMSIG_BASICMOB_LOOK_DEAD)
 
+//Basic mobs are dead when their health hits 0, for some reason living makes assumptions on behalf of carbons.
+/mob/living/basic/can_be_revived()
+	if(health <= 0)
+		return FALSE
+	return TRUE
+
 /mob/living/basic/revive(full_heal_flags = NONE, excess_healing = 0, force_grab_ghost = FALSE)
 	. = ..()
 	if(!.)

--- a/code/modules/surgery/organic_steps.dm
+++ b/code/modules/surgery/organic_steps.dm
@@ -66,7 +66,7 @@
 	time = 24
 	preop_sound = 'sound/items/handling/surgery/hemostat1.ogg'
 
-/datum/surgery_step/clamp_bleeders/preop(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
+/datum/surgery_step/clamp_bleeders/preop(mob/user, mob/living/target, target_zone, obj/item/tool, datum/surgery/surgery)
 	display_results(
 		user,
 		target,
@@ -76,9 +76,12 @@
 	)
 	display_pain(target, "You feel a pinch as the bleeding in your [target.parse_zone_with_bodypart(target_zone)] is slowed.")
 
-/datum/surgery_step/clamp_bleeders/success(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery, default_display_results)
+/datum/surgery_step/clamp_bleeders/success(mob/user, mob/living/target, target_zone, obj/item/tool, datum/surgery/surgery, default_display_results)
 	if(locate(/datum/surgery_step/saw) in surgery.steps)
-		target.heal_bodypart_damage(20, 0, target_zone = target_zone)
+		if(isbasicmob(target))
+			target.heal_bodypart_damage(target.maxHealth * 0.1, 0, target_zone = target_zone)
+		else
+			target.heal_bodypart_damage(20, 0, target_zone = target_zone)
 	if (ishuman(target))
 		var/mob/living/carbon/human/human_target = target
 		var/obj/item/bodypart/target_bodypart = human_target.get_bodypart(target_zone)
@@ -171,7 +174,7 @@
 	success_sound = 'sound/items/handling/surgery/organ2.ogg'
 	surgery_effects_mood = TRUE
 
-/datum/surgery_step/saw/preop(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
+/datum/surgery_step/saw/preop(mob/user, mob/living/target, target_zone, obj/item/tool, datum/surgery/surgery)
 	display_results(
 		user,
 		target,
@@ -186,8 +189,11 @@
 		return FALSE
 	return TRUE
 
-/datum/surgery_step/saw/success(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery, default_display_results)
-	target.apply_damage(50, BRUTE, "[target_zone]", wound_bonus=CANT_WOUND)
+/datum/surgery_step/saw/success(mob/user, mob/living/target, target_zone, obj/item/tool, datum/surgery/surgery, default_display_results)
+	if(isbasicmob(target))
+		target.apply_damage(target.maxHealth * 0.25, BRUTE, "[target_zone]", wound_bonus=CANT_WOUND)
+	else
+		target.apply_damage(50, BRUTE, "[target_zone]", wound_bonus=CANT_WOUND)
 	display_results(
 		user,
 		target,

--- a/code/modules/surgery/revival.dm
+++ b/code/modules/surgery/revival.dm
@@ -111,7 +111,10 @@
 		span_notice("[user] send a powerful shock to [target]'s brain with [tool]..."),
 	)
 	target.grab_ghost()
-	target.adjustOxyLoss(-50)
+	if(isbasicmob(target))
+		target.adjustOxyLoss(-target.maxHealth)
+	else
+		target.adjustOxyLoss(-50)
 	if(iscarbon(target))
 		var/mob/living/carbon/carbon_target = target
 		carbon_target.set_heartattack(FALSE)


### PR DESCRIPTION
## About The Pull Request

This PR fixes being able to not revive basic mobs in some cases, or in other cases the mob visually looking revived but not actually being revived due to some faulty code. The steps used in revival surgery, if used on a basic mob, do proportional damage now, so mobs like Ian who have 20 max health or less can be revived properly. Also makes the final revival step heal all oxygen damage for basic mobs, which pairs nicely with the other changes I made to allow them to receive it.

## Why It's Good For The Game

This shit was really buggy and some stuff clearly not thought through, you can actually get Punished Ian now without the laz injector from mining.

## Changelog

:cl:
fix: Basic mob revival surgery now works like you'd expect.
/:cl: