### PR TITLE
Surgery Chems Stack Additively

### DIFF
--- a/code/__DEFINES/surgery.dm
+++ b/code/__DEFINES/surgery.dm
@@ -102,3 +102,10 @@
 
 ///Return true if target is not in a valid body position for the surgery
 #define IS_IN_INVALID_SURGICAL_POSITION(target, surgery) ((surgery.surgery_flags & SURGERY_REQUIRE_RESTING) && (target.mobility_flags & MOBILITY_LIEDOWN && target.body_position != LYING_DOWN))
+
+// Defines for all the different chems that can apply speed modifiers to surgery.
+#define SURGERY_SPEED_MODIFIER_HONEY "speed_mod_honey"
+#define SURGERY_SPEED_MODIFIER_MINE_SALVE "speed_mod_mine_salve"
+#define SURGERY_SPEED_MODIFIER_ANTIHOL "speed_mod_antihol"
+#define SURGERY_SPEED_MODIFIER_STERILIZINE "speed_mod_sterilizine"
+#define SURGERY_SPEED_MODIFIER_ETHANOL "speed_mod_ethanol"

--- a/code/modules/reagents/chemistry/reagents/drinks/alcohol_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drinks/alcohol_reagents.dm
@@ -104,7 +104,10 @@
 		exposed_mob.adjust_fire_stacks(reac_volume / 15)
 		var/power_multiplier = boozepwr / 65 // Weak alcohol has less sterilizing power
 		for(var/datum/surgery/surgery as anything in exposed_mob.surgeries)
-			surgery.speed_modifier = max(0.1 * power_multiplier, surgery.speed_modifier)
+			if(SURGERY_SPEED_MODIFIER_ETHANOL in surgery.speed_modifier_list)
+				continue
+			surgery.speed_modifier_list += SURGERY_SPEED_MODIFIER_ETHANOL
+			surgery.speed_modifier += 0.1 * power_multiplier
 
 /datum/reagent/consumable/ethanol/beer
 	name = "Beer"

--- a/code/modules/reagents/chemistry/reagents/food_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/food_reagents.dm
@@ -840,12 +840,14 @@
 
 /datum/reagent/consumable/honey/expose_mob(mob/living/exposed_mob, methods=TOUCH, reac_volume)
 	. = ..()
-	if(!iscarbon(exposed_mob) || !(methods & (TOUCH|VAPOR|PATCH)))
+	if(!(methods & (TOUCH|VAPOR|PATCH)))
 		return
 
-	var/mob/living/carbon/exposed_carbon = exposed_mob
-	for(var/datum/surgery/surgery as anything in exposed_carbon.surgeries)
-		surgery.speed_modifier = max(0.6, surgery.speed_modifier)
+	for(var/datum/surgery/surgery as anything in exposed_mob.surgeries)
+		if(SURGERY_SPEED_MODIFIER_HONEY in surgery.speed_modifier_list)
+			continue
+		surgery.speed_modifier_list += SURGERY_SPEED_MODIFIER_HONEY
+		surgery.speed_modifier += 0.6
 
 /datum/reagent/consumable/mayonnaise
 	name = "Mayonnaise"

--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -361,12 +361,14 @@
 			to_chat(exposed_mob, span_warning("Your stomach feels empty and cramps!"))
 
 	if(methods & (PATCH|TOUCH))
-		var/mob/living/carbon/exposed_carbon = exposed_mob
-		for(var/datum/surgery/surgery as anything in exposed_carbon.surgeries)
-			surgery.speed_modifier = max(0.1, surgery.speed_modifier)
+		for(var/datum/surgery/surgery as anything in exposed_mob.surgeries)
+			if(SURGERY_SPEED_MODIFIER_MINE_SALVE in surgery.speed_modifier_list)
+				continue
+			surgery.speed_modifier_list += SURGERY_SPEED_MODIFIER_MINE_SALVE
+			surgery.speed_modifier += 0.1
 
 		if(show_message)
-			to_chat(exposed_carbon, span_danger("You feel your injuries fade away to nothing!") )
+			to_chat(exposed_mob, span_danger("You feel your injuries fade away to nothing!") )
 
 /datum/reagent/medicine/mine_salve/on_mob_metabolize(mob/living/affected_mob)
 	. = ..()
@@ -1158,13 +1160,16 @@
 		. = UPDATE_MOB_HEALTH
 	affected_mob.adjust_drunk_effect(-10 * REM * seconds_per_tick * normalise_creation_purity())
 
-/datum/reagent/medicine/antihol/expose_mob(mob/living/carbon/exposed_carbon, methods=TOUCH, reac_volume)
+/datum/reagent/medicine/antihol/expose_mob(mob/living/exposed_mob, methods=TOUCH, reac_volume)
 	. = ..()
 	if(!(methods & (TOUCH|VAPOR|PATCH)))
 		return
 
-	for(var/datum/surgery/surgery as anything in exposed_carbon.surgeries)
-		surgery.speed_modifier = max(surgery.speed_modifier  - 0.1, -0.9)
+	for(var/datum/surgery/surgery as anything in exposed_mob.surgeries)
+		if(SURGERY_SPEED_MODIFIER_ANTIHOL in surgery.speed_modifier_list)
+			continue
+		surgery.speed_modifier_list += SURGERY_SPEED_MODIFIER_ANTIHOL
+		surgery.speed_modifier -= -0.1
 
 /datum/reagent/medicine/stimulants
 	name = "Stimulants"

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -1193,13 +1193,16 @@
 	ph = 10.5
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED|REAGENT_AFFECTS_WOUNDS
 
-/datum/reagent/space_cleaner/sterilizine/expose_mob(mob/living/carbon/exposed_carbon, methods=TOUCH, reac_volume)
+/datum/reagent/space_cleaner/sterilizine/expose_mob(mob/living/exposed_mob, methods=TOUCH, reac_volume)
 	. = ..()
 	if(!(methods & (TOUCH|VAPOR|PATCH)))
 		return
 
-	for(var/datum/surgery/surgery as anything in exposed_carbon.surgeries)
-		surgery.speed_modifier = max(0.2, surgery.speed_modifier)
+	for(var/datum/surgery/surgery as anything in exposed_mob.surgeries)
+		if(SURGERY_SPEED_MODIFIER_STERILIZINE in surgery.speed_modifier_list)
+			continue
+		surgery.speed_modifier_list += SURGERY_SPEED_MODIFIER_STERILIZINE
+		surgery.speed_modifier += 0.2
 
 /datum/reagent/space_cleaner/sterilizine/on_burn_wound_processing(datum/wound/burn/flesh/burn_wound)
 	burn_wound.sanitization += 0.9

--- a/code/modules/surgery/surgery.dm
+++ b/code/modules/surgery/surgery.dm
@@ -32,6 +32,8 @@
 	///The types of bodyparts that this surgery can have performed on it. Used for augmented surgeries.
 	var/requires_bodypart_type = BODYTYPE_ORGANIC
 
+	///A list of speed modifiers already applied to this surgery, to prevent stacking.
+	var/list/speed_modifier_list = list()
 	///The speed modifier given to the surgery through external means.
 	var/speed_modifier = 0
 	///Whether the surgery requires research to do. You need to add a design if using this!


### PR DESCRIPTION
## About The Pull Request

Surgery chems now stack additively, as opposed to taking the best modifier.

## Why It's Good For The Game

If people want to use a combination of chems to speed up surgery, that's good emergent gameplay and we should reward them.

## Changelog

:cl:
add: Chems that increase surgery speed now stack additively.
/:cl:
