### PR TITLE
Janitor's Revenge: Traitor Janitor Buff

### DIFF
--- a/code/datums/mind/antag.dm
+++ b/code/datums/mind/antag.dm
@@ -176,6 +176,7 @@
 	new_uplink.uplink_handler.owner = traitor_mob.mind
 	new_uplink.uplink_handler.assigned_role = traitor_mob.mind.assigned_role.title
 	new_uplink.uplink_handler.assigned_species = traitor_mob.dna.species.id
+	new_uplink.uplink_handler.add_telecrystals(traitor_mob.mind.assigned_role.traitor_bonus_tc)
 
 	unlock_text = "Your Uplink is cunningly disguised as your [uplink_loc.name]. "
 	if(istype(uplink_loc, /obj/item/modular_computer/pda))

--- a/code/modules/jobs/job_types/_job.dm
+++ b/code/modules/jobs/job_types/_job.dm
@@ -135,6 +135,9 @@
 	/// If set, look for a policy with this instead of the job title
 	var/policy_override
 
+	/// If this job gets bonus TC when assigned traitor and how much
+	var/traitor_bonus_tc = 0
+
 /datum/job/New()
 	. = ..()
 	var/new_spawn_positions = CHECK_MAP_JOB_CHANGE(title, "spawn_positions")

--- a/code/modules/jobs/job_types/janitor.dm
+++ b/code/modules/jobs/job_types/janitor.dm
@@ -8,6 +8,7 @@
 	supervisors = SUPERVISOR_HOP
 	exp_granted_type = EXP_TYPE_CREW
 	config_tag = "JANITOR"
+	traitor_bonus_tc = 10
 
 	outfit = /datum/outfit/job/janitor
 	plasmaman_outfit = /datum/outfit/plasmaman/janitor

--- a/code/modules/uplink/uplink_items/job.dm
+++ b/code/modules/uplink/uplink_items/job.dm
@@ -119,6 +119,15 @@
 	surplus = 20
 	restricted_roles = list(JOB_JANITOR)
 
+/datum/uplink_item/role_restricted/virus_grenade_janitor
+	name = "Fungal Tuberculosis Grenade Box"
+	desc = "A primed bio-grenade packed into a compact box. Comes with five Bio Virus Antidote Kit (BVAK) \
+		autoinjectors for rapid application on up to two targets each, a syringe, and a bottle containing \
+		the BVAK solution."
+	item = /obj/item/storage/box/syndie_kit/tuberculosisgrenade
+	cost = 25
+	restricted_roles = list(JOB_JANITOR)
+
 /datum/uplink_item/role_restricted/reverse_bear_trap
 	name = "Reverse Bear Trap"
 	desc = "An ingenious execution device worn on (or forced onto) the head. Arming it starts a 1-minute kitchen timer mounted on the bear trap. When it goes off, the trap's jaws will \
@@ -403,3 +412,10 @@
 	progression_minimum = 30 MINUTES
 	purchasable_from = parent_type::purchasable_from & ~UPLINK_SPY
 
+/datum/uplink_item/role_restricted/manifold_injector
+	name = "EHMS Autoinjector"
+	desc = "Stands for Experimental Hereditary Manifold Sickness. Inject this into a target to greatly dehabilitate them, though the effects \
+		can be staved off with proper medication."
+	item = /obj/item/reagent_containers/hypospray/medipen/manifoldinjector
+	cost = 5
+	restricted_roles = list(JOB_JANITOR, JOB_MEDICAL_DOCTOR, JOB_CHIEF_MEDICAL_OFFICER, JOB_PARAMEDIC, JOB_GENETICIST)


### PR DESCRIPTION
## About The Pull Request

This PR does the following:

- Janitor gets 30 TC as traitor as opposed to 20
- Janitor can purchase fungal tuberculosis for 25 TC
- Janitor, Medical Doctor, CMO, Paramedic and Geneticist can purchase EHMS injectors for 5 TC a pop.

## Why It's Good For The Game

We removed Janitor's paycheck, so he's mad now. EHMS was removed content as of us removing progtot so now its available to traitors again.

## Changelog

:cl:
add: Janitor gets 30 TC as opposed to 20
add: Janitor can purchase fungal TB for 25 TC
add: Janitor, Medical Doctor, CMO, Paramedic and Geneticist can purchase EHMS injectors from the uplink for 5 TC.
/:cl:
