### PR TITLE
Fire extinguishers and reagent dispensers are injectable.

### DIFF
--- a/code/game/objects/items/extinguisher.dm
+++ b/code/game/objects/items/extinguisher.dm
@@ -130,7 +130,7 @@
 /obj/item/extinguisher/proc/refill()
 	if(!chem)
 		return
-	create_reagents(max_water, AMOUNT_VISIBLE)
+	create_reagents(max_water, AMOUNT_VISIBLE|INJECTABLE)
 	reagents.add_reagent(chem, max_water)
 
 /obj/item/extinguisher/Initialize(mapload)
@@ -140,7 +140,7 @@
 	if(starting_water)
 		refill()
 	else if(chem)
-		create_reagents(max_water, AMOUNT_VISIBLE)
+		create_reagents(max_water, AMOUNT_VISIBLE|INJECTABLE)
 
 /obj/item/extinguisher/advanced
 	name = "advanced fire extinguisher"

--- a/code/modules/reagents/reagent_dispenser.dm
+++ b/code/modules/reagents/reagent_dispenser.dm
@@ -150,7 +150,7 @@
 	UnregisterSignal(src, COMSIG_IGNITER_ACTIVATE)
 
 /obj/structure/reagent_dispensers/Initialize(mapload)
-	create_reagents(tank_volume, DRAINABLE | AMOUNT_VISIBLE)
+	create_reagents(tank_volume, DRAINABLE | AMOUNT_VISIBLE | INJECTABLE)
 	if(reagent_id)
 		reagents.add_reagent(reagent_id, tank_volume)
 	. = ..()


### PR DESCRIPTION
## About The Pull Request

You can use IV drips to inject liquids into fire extinguishers and reagent dispensers.

## Why It's Good For The Game

More sandbox elements, was a request. We'll see how it goes.

## Changelog

:cl:
add: You can use IV drips to inject reagents into fire extinguishers and reagent dispensers.
/:cl: