### PR TITLE
No More Bombanna! - A tale of the worlds smallest PR

### DIFF
--- a/_maps/map_files/boxstation/ProtoBoxStation.dmm
+++ b/_maps/map_files/boxstation/ProtoBoxStation.dmm
@@ -21308,7 +21308,7 @@
 /turf/open/floor/plating,
 /area/station/science/robotics/lab)
 "bru" = (
-/obj/item/food/grown/banana/bombanana,
+/obj/item/food/grown/banana,
 /turf/open/floor/grass,
 /area/station/science/genetics)
 "brv" = (


### PR DESCRIPTION
## About The Pull Request

apparently proto box just has a bomb banana in the genetics pen. that the monkeys eat. and explode.

it would literally space all of genetics 😭 

now it is no longer there

## Why It's Good For The Game

geneticists can now play the game on protobox!!! what a beautiful world we live in.

## Changelog

:cl:
fix: allowed geneticists to once more play the video game on boxstation
/:cl: