### PR TITLE
silly floating effect for the prop hat

### DIFF
--- a/code/modules/clothing/head/soft_caps.dm
+++ b/code/modules/clothing/head/soft_caps.dm
@@ -197,6 +197,7 @@
 
 /obj/item/clothing/head/soft/propeller_hat/attack_self(mob/user)
 	active = !active
+	active ? handle_anim(user, TRUE) : handle_anim(user, FALSE)
 	balloon_alert(user, (active ? "started propeller" : "stopped propeller"))
 	update_icon()
 	user.update_worn_head()
@@ -209,8 +210,16 @@
 
 /obj/item/clothing/head/soft/propeller_hat/dropped(mob/living/user)
 	. = ..()
+	handle_anim(user, FALSE)
 	user.clear_mood_event(PROPHAT_MOOD)
 	active = FALSE
 	update_icon()
+
+//no i am not putting any effort into not breaking the floating anim for a silly feature.
+/obj/item/clothing/head/soft/propeller_hat/proc/handle_anim(mob/living/target, state)
+	if(state)
+		DO_FLOATING_ANIM(target)
+	else
+		STOP_FLOATING_ANIM(target)
 
 #undef PROPHAT_MOOD


### PR DESCRIPTION

## About The Pull Request

![club-penguin-propeller-hat](https://github.com/user-attachments/assets/4534f131-69a6-43dc-80d7-f1b662f388a0)


## Why It's Good For The Game

it makes you look silly

## Changelog

active prop hat gives you a floating effect for further immersion.

:cl:
add: Added new mechanics or gameplay changes
/:cl:


