### PR TITLE
Super Tiny Kneecapping Fix

### DIFF
--- a/code/game/objects/items/maintenance_loot.dm
+++ b/code/game/objects/items/maintenance_loot.dm
@@ -25,9 +25,9 @@
 	throw_drop_sound = 'sound/items/handling/lead_pipe/lead_pipe_drop.ogg'
 	hitsound = 'sound/items/lead_pipe_hit.ogg'
 
-	/obj/item/lead_pipe/Initialize(mapload)
-		. = ..()
-		AddElement(/datum/element/kneecapping)
+/obj/item/lead_pipe/Initialize(mapload)
+	. = ..()
+	AddElement(/datum/element/kneecapping)
 
 //A good battery early in the shift. Source of lead & sulfuric acid reagents.
 //Add lead material to this once implemented.


### PR DESCRIPTION
## About The Pull Request

my error plugins kept throwing it at me, so here it is.

the initialization code for the lead pipe kneecapping was nested inside the lead pipe itself, which isn't good.

## Why It's Good For The Game

i like buges... 🐛 ... but sometimes we are better with a few less

## Changelog

:cl:
fix: unnested the lead pipe kneecapping init
/:cl:
