### PR TITLE
Molotov Buff

### DIFF
--- a/code/game/objects/effects/decals/cleanable/misc.dm
+++ b/code/game/objects/effects/decals/cleanable/misc.dm
@@ -555,6 +555,10 @@
 	else if(istype(enflammable_atom, /obj/effect/particle_effect/sparks))
 		ignite()
 
+/obj/effect/decal/cleanable/fuel_pool/molotov
+	name = "pool of molotov fuel"
+	desc = "A pool of flammable fuel. I think it's burning..."
+	icon_state = "thermite"
 
 /obj/effect/decal/cleanable/fuel_pool/hivis
 	icon_state = "fuel_pool_hivis"

--- a/code/modules/atmospherics/environmental/LINDA_fire.dm
+++ b/code/modules/atmospherics/environmental/LINDA_fire.dm
@@ -132,6 +132,8 @@
 	if(!isnull(starting_temperature))
 		temperature = starting_temperature
 	perform_exposure()
+	if(QDELETED(src)) // It is actually possible for this hotspot to become qdeleted in perform_exposure() if another hotspot gets created (for example in fire_act() of fuel pools)
+		return // In this case, we want to just leave and let the new hotspot take over.
 	setDir(pick(GLOB.cardinals))
 	air_update_turf(FALSE, FALSE)
 	var/static/list/loc_connections = list(
@@ -348,7 +350,8 @@
 	SSair.hotspots -= src
 	var/turf/open/T = loc
 	if(istype(T) && T.active_hotspot == src)
-		our_hot_group.remove_from_group(src)
+		if(our_hot_group)
+			our_hot_group.remove_from_group(src)
 		our_hot_group = null
 		T.set_active_hotspot(null)
 	return ..()
@@ -405,6 +408,8 @@
 		return
 
 /datum/hot_group/proc/add_to_group(obj/effect/hotspot/target)
+	if(QDELETED(target))
+		return
 	spot_list += target
 	target.our_hot_group = src
 	var/turf/open/target_turf = target.loc

--- a/code/modules/reagents/reagent_containers/cups/glassbottle.dm
+++ b/code/modules/reagents/reagent_containers/cups/glassbottle.dm
@@ -901,7 +901,7 @@
 	icon_state = "vodkabottle"
 	list_reagents = list()
 	var/active = FALSE
-	var/coolfire = FALSE
+	var/bigfire = FALSE
 	var/list/accelerants = list(
 		/datum/reagent/consumable/ethanol,
 		/datum/reagent/fuel,
@@ -935,9 +935,11 @@
 				firestarter = 1
 				break
 	..()
-	if(firestarter && active)
+	if (!firestarter && !active)
+		return
+	else
 		target.fire_act()
-		if(coolfire == TRUE)
+		if(bigfire == TRUE)
 			for(var/turf/nearby_turf in RANGE_TURFS(2, target))
 				if(!locate(/obj/effect/hotspot) in nearby_turf)
 					var/obj/effect/decal/cleanable/fuel_pool/molotov/pool = nearby_turf.spawn_unique_cleanable(/obj/effect/decal/cleanable/fuel_pool/molotov)
@@ -961,7 +963,7 @@
 		if(!isGlass)
 			addtimer(CALLBACK(src, PROC_REF(explode)), 5 SECONDS)
 		if(reagents.total_volume >= 60)
-			coolfire = TRUE
+			bigfire = TRUE
 
 /obj/item/reagent_containers/cup/glass/bottle/molotov/proc/explode()
 	if(!active)

--- a/code/modules/reagents/reagent_containers/cups/glassbottle.dm
+++ b/code/modules/reagents/reagent_containers/cups/glassbottle.dm
@@ -938,8 +938,7 @@
 
 	if(!firestarter || !active)
 		return
-	else
-		target.fire_act()
+	target.fire_act()
 	for(var/turf/nearby_turf in RANGE_TURFS((bigfire ? 2 : 1), target))
 		if(locate(/obj/effect/hotspot) in nearby_turf)
 			return

--- a/code/modules/reagents/reagent_containers/cups/glassbottle.dm
+++ b/code/modules/reagents/reagent_containers/cups/glassbottle.dm
@@ -935,22 +935,17 @@
 				firestarter = 1
 				break
 	..()
-	if (!firestarter && !active)
+
+	if(!firestarter || !active)
 		return
 	else
 		target.fire_act()
-		if(bigfire == TRUE)
-			for(var/turf/nearby_turf in RANGE_TURFS(2, target))
-				if(!locate(/obj/effect/hotspot) in nearby_turf)
-					var/obj/effect/decal/cleanable/fuel_pool/molotov/pool = nearby_turf.spawn_unique_cleanable(/obj/effect/decal/cleanable/fuel_pool/molotov)
-					pool.burn_amount = 10
-					pool.ignite()
-		else
-			for(var/turf/nearby_turf in RANGE_TURFS(1, target))
-				if(!locate(/obj/effect/hotspot) in nearby_turf)
-					var/obj/effect/decal/cleanable/fuel_pool/molotov/pool = nearby_turf.spawn_unique_cleanable(/obj/effect/decal/cleanable/fuel_pool/molotov)
-					pool.burn_amount = 5
-					pool.ignite()
+	for(var/turf/nearby_turf in RANGE_TURFS((bigfire ? 2 : 1), target))
+		if(locate(/obj/effect/hotspot) in nearby_turf)
+			return
+		var/obj/effect/decal/cleanable/fuel_pool/molotov/pool = nearby_turf.spawn_unique_cleanable(/obj/effect/decal/cleanable/fuel_pool/molotov)
+		pool.burn_amount = (bigfire ? 10 : 5)
+		pool.ignite()
 
 
 /obj/item/reagent_containers/cup/glass/bottle/molotov/attackby(obj/item/I, mob/user, params)

--- a/code/modules/reagents/reagent_containers/cups/glassbottle.dm
+++ b/code/modules/reagents/reagent_containers/cups/glassbottle.dm
@@ -901,6 +901,7 @@
 	icon_state = "vodkabottle"
 	list_reagents = list()
 	var/active = FALSE
+	var/coolfire = FALSE
 	var/list/accelerants = list(
 		/datum/reagent/consumable/ethanol,
 		/datum/reagent/fuel,
@@ -936,7 +937,19 @@
 	..()
 	if(firestarter && active)
 		target.fire_act()
-		new /obj/effect/hotspot(get_turf(target))
+		if(coolfire == TRUE)
+			for(var/turf/nearby_turf in RANGE_TURFS(2, target))
+				if(!locate(/obj/effect/hotspot) in nearby_turf)
+					var/obj/effect/decal/cleanable/fuel_pool/molotov/pool = nearby_turf.spawn_unique_cleanable(/obj/effect/decal/cleanable/fuel_pool/molotov)
+					pool.burn_amount = 10
+					pool.ignite()
+		else
+			for(var/turf/nearby_turf in RANGE_TURFS(1, target))
+				if(!locate(/obj/effect/hotspot) in nearby_turf)
+					var/obj/effect/decal/cleanable/fuel_pool/molotov/pool = nearby_turf.spawn_unique_cleanable(/obj/effect/decal/cleanable/fuel_pool/molotov)
+					pool.burn_amount = 5
+					pool.ignite()
+
 
 /obj/item/reagent_containers/cup/glass/bottle/molotov/attackby(obj/item/I, mob/user, params)
 	if(I.get_temperature() && !active)
@@ -947,6 +960,8 @@
 		add_overlay(custom_fire_overlay ? custom_fire_overlay : GLOB.fire_overlay)
 		if(!isGlass)
 			addtimer(CALLBACK(src, PROC_REF(explode)), 5 SECONDS)
+		if(reagents.total_volume >= 60)
+			coolfire = TRUE
 
 /obj/item/reagent_containers/cup/glass/bottle/molotov/proc/explode()
 	if(!active)


### PR DESCRIPTION
## About The Pull Request
makes molotov actually good weapon now. makes molotov spill ignited molotov fuel (subtype of regular) instead of making short-lived hotspot. molotov affects now 3x3 or 5x5 area, depends if you have more or less than 60 reagents inside of it. (also reagents amount affect duration of fire)
![image](https://github.com/user-attachments/assets/df76f757-2002-4155-a88c-eaef982be8f7)

also merged [this pr](https://github.com/tgstation/tgstation/pull/89195) inside of this one, i believe this is needed.

## Why It's Good For The Game

1x1 molotov sux

## Changelog

:cl:
qol: Now ignited Molotov is spilling the corresponding fuel over a large area after being throwed instead of 1x1 fire.
/:cl:
