### PR TITLE
Fertilizer buff: Benzoic Acid and Brimdust (reagent)

### DIFF
--- a/code/modules/reagents/chemistry/reagents/impure_reagents/impure_medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/impure_reagents/impure_medicine_reagents.dm
@@ -770,10 +770,10 @@ Basically, we fill the time between now and 2s from now with hands based off the
 	tox_damage = 0
 
 /datum/reagent/inverse/sal_acid/on_hydroponics_apply(obj/machinery/hydroponics/mytray, mob/user)
-	mytray.adjust_plant_health(round(volume * 0.5))
-	mytray.myseed?.adjust_production(-round(volume * 0.2))
-	mytray.myseed?.adjust_potency(round(volume * 0.25))
-	mytray.myseed?.adjust_yield(round(volume * 0.2))
+	mytray.adjust_plant_health(round(volume * 1.2))
+	mytray.myseed?.adjust_production(-round(volume * 0.8))
+	mytray.myseed?.adjust_potency(round(volume))
+	mytray.myseed?.adjust_yield(round(volume * 0.8))
 
 /datum/reagent/inverse/oxandrolone
 	name = "Oxymetholone"

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -3054,7 +3054,7 @@
 
 /datum/reagent/brimdust
 	name = "Brimdust"
-	description = "A brimdemon's dust. Consumption is not recommended, although plants like it."
+	description = "A brimdemon's dust. Consumption is not recommended, although it can be used on plants to rapidly heal them."
 	reagent_state = SOLID
 	color = "#522546"
 	taste_description = "burning"
@@ -3066,10 +3066,10 @@
 		return UPDATE_MOB_HEALTH
 
 /datum/reagent/brimdust/on_hydroponics_apply(obj/machinery/hydroponics/mytray, mob/user)
-	mytray.adjust_weedlevel(-1)
-	mytray.adjust_pestlevel(-1)
-	mytray.adjust_plant_health(round(volume))
-	mytray.myseed?.adjust_potency(round(volume * 0.5))
+	mytray.adjust_weedlevel(-3)
+	mytray.adjust_pestlevel(-3)
+	mytray.adjust_plant_health(round(volume * 3))
+	mytray.myseed?.adjust_potency(round(volume))
 
 // I made this food....with love.
 // Reagent added to food by chef's with a chef's kiss. Makes people happy.

--- a/code/modules/reagents/reagent_containers/cups/bottle.dm
+++ b/code/modules/reagents/reagent_containers/cups/bottle.dm
@@ -106,6 +106,11 @@
 	desc = "A small bottle of diethylamine."
 	list_reagents = list(/datum/reagent/diethylamine = 30)
 
+/obj/item/reagent_containers/cup/bottle/brimdust
+	name = "brimdust bottle"
+	desc = "A small bottle of brimdust."
+	list_reagents = list(/datum/reagent/brimdust = 30)
+
 /obj/item/reagent_containers/cup/bottle/facid
 	name = "Fluorosulfuric Acid Bottle"
 	desc = "A small bottle. Contains a small amount of fluorosulfuric acid."

--- a/code/modules/vending/nutrimax.dm
+++ b/code/modules/vending/nutrimax.dm
@@ -23,6 +23,7 @@
 		/obj/item/reagent_containers/cup/bottle/ammonia = 10,
 		/obj/item/reagent_containers/cup/bottle/diethylamine = 5,
 		/obj/item/reagent_containers/cup/bottle/saltpetre = 5,
+		/obj/item/reagent_containers/cup/bottle/brimdust = 3,
 	)
 	refill_canister = /obj/item/vending_refill/hydronutrients
 	default_price = PAYCHECK_CREW * 0.8


### PR DESCRIPTION
## About The Pull Request

makes benzoic acid and brimdust actually good comparing to other botany reagents.

makes nutrimax selling 3 bottles of brimdust (30u each) in contraband section.
![image](https://github.com/user-attachments/assets/c4d7e872-6851-4d40-a7ae-dcacbdaa19d4)


## Why It's Good For The Game

amount of effort to create those fertilizer should be more rewardable.

## Changelog

:cl:
qol: Benzoic Acid and Brimdust are now more robust.
/:cl:
